### PR TITLE
Table changes w.r.t. J!1.5: Banners, banner_clients and languages content elements change

### DIFF
--- a/component/admin/contentelements/banner_clients.xml
+++ b/component/admin/contentelements/banner_clients.xml
@@ -6,8 +6,8 @@
   <description>Definition for the core banner component</description>
   <copyright>2003 - 2012, Think Network GmbH, Munich</copyright>
  <reference>
-  	<table name="bannerclient">
-  		<field type="referenceid" name="cid" translate="0">ID</field>
+  	<table name="banner_clients">
+  		<field type="referenceid" name="id" translate="0">ID</field>
   		<field type="titletext" name="name" translate="1">Client Name</field>
   		<field type="text" name="contact" translate="1">Contact Name</field>
   		<field type="text" name="email" translate="1">Contact Email</field>

--- a/component/admin/contentelements/banners.xml
+++ b/component/admin/contentelements/banners.xml
@@ -6,15 +6,14 @@
   <description>Definition for the core banner component</description>
   <copyright>2003 - 2012, Think Network GmbH, Munich</copyright>
   <reference>
-  	<table name="banner">
-  		<field type="referenceid" name="bid" translate="0">ID</field>
+  	<table name="banners">
+  		<field type="referenceid" name="id" translate="0">ID</field>
   		<field type="titletext" name="name" translate="1">Banner Name</field>
-		<field type="text" name="imageurl" translate="1">Banner file name</field>
   		<field type="text" name="clickurl" translate="1">Click URL</field>
   		<field type="textarea" name="custombannercode" translate="1">Custom banner code</field>
   	</table>
   	<component>
-  		<form>com_banners#banner#cid#task#!edit</form>
+  		<form>com_banners#banners#id#task#!edit</form>
   	</component>
    </reference>
 </joomfish>

--- a/component/admin/contentelements/languages.xml
+++ b/component/admin/contentelements/languages.xml
@@ -7,8 +7,8 @@
   <copyright>2003 - 2012, Think Network GmbH, Munich</copyright>
  <reference type="content">
     <table name="languages">
-      <field type="referenceid" name="id" translate="0">ID</field>
-      <field type="titletext" name="name" translate="1">Title</field>
+      <field type="referenceid" name="lang_id" translate="0">ID</field>
+      <field type="titletext" name="title" translate="1">Title</field>
     </table>
   </reference>
   <translationfilters>


### PR DESCRIPTION
**table #__banner is renamed: #_banners and some fields were changed**
- filename banners (rename)
- table name="banners"
- bid -> id
- remove name="imageurl" field, image location is now in Parameters (table field Params). I don't know how to add Parameters..., but with these changes there no longer is an error.

**table #__bannerclient is renamed: #_banner_clients and a field was changed**
- filename banner_clients
- table name banner_clients
- cid -> id

**table #__languages has no 'id' column, it has a 'lang_id'**
- name="id" -> name="lang_id"
- name="name" -> name="title"
  Note that

`````` <translationfilters>```
```    <published>published</published>```
```  </translationfilters>```
is not a problem, this table has the published column, not a state column.

**Possible issue**
I'm not 100% sure about this line, don't really know what it's for, but sinces banner was changed to banners and cid to id, I did this also in this line:
```<form>com_banners#banner#cid#task#!edit</form>```

**Tests**
I tested these content element changes in the backend of J!1.7.3: no fatal errors (anymore), no notices, translations for these three content elements can be edited and saved.
``````
