### PR TITLE
Change index3.php to index.php in Manage Translation and Statistics screens

### DIFF
--- a/admin/controllers/manage.php
+++ b/admin/controllers/manage.php
@@ -104,7 +104,7 @@ class ManageController extends JController  {
 					$htmlResult = $this->_view->renderCopyInformation($original2languageInfo, $message, $langlist);
 				} elseif( $phase == 2 || $phase == 3 ) {
 					$htmlResult = $this->_view->renderCopyProcess($original2languageInfo, $message);
-					$link = 'index3.php?option=com_joomfish&task=manage.copy&type=original_language&phase=' .$phase. '&language_id=' .$language_id. '&state_catid=' .$state_catid. '&overwrite=' .$overwrite;
+					$link = 'index.php?option=com_joomfish&task=manage.copy&type=original_language&phase=' .$phase. '&language_id=' .$language_id. '&state_catid=' .$state_catid. '&overwrite=' .$overwrite;
 				} else {
 					$htmlResult = $this->_view->renderCopyProcess($original2languageInfo, $message);
 					$session->set('original2languageInfo', null );

--- a/admin/controllers/statistics.php
+++ b/admin/controllers/statistics.php
@@ -96,7 +96,7 @@ class StatisticsController extends JController  {
 
 				$htmlResult = $this->_view->renderTranslationStatusTable($translationStatus, $message);
 				if( $phase<=3 ) {
-					$link = 'index3.php?option=com_joomfish&task=statistics.check&type=translation_status&phase=' .$phase;
+					$link = 'index.php?option=com_joomfish&task=statistics.check&type=translation_status&phase=' .$phase;
 
 					if( $statecheck_i > -1) {
 						$link .= '&statecheck_i='.$statecheck_i;
@@ -122,7 +122,7 @@ class StatisticsController extends JController  {
 				$htmlResult = $this->_view->renderOriginalStatusTable($originalStatus, $message, $langCodes);
 
 				if( $phase<=2 ) {
-					$link = 'index3.php?option=com_joomfish&task=statistics.check&type=original_status&phase=' .$phase;
+					$link = 'index.php?option=com_joomfish&task=statistics.check&type=original_status&phase=' .$phase;
 
 					if( $statecheck_i > -1) {
 						$link .= '&statecheck_i='.$statecheck_i;

--- a/admin/views/manage/tmpl/default.php
+++ b/admin/views/manage/tmpl/default.php
@@ -44,7 +44,7 @@ defined('_JEXEC') or die('Restricted access'); ?>
   function executeCopyOriginal( toLanguage, confirmCheck, copyCat  ) {
   		if( toLanguage == null || toLanguage.value == -1 ) return;
 
-		var link = 'index3.php?option=com_joomfish&task=manage.copy&type=original_language&phase=2';
+		var link = 'index.php?option=com_joomfish&task=manage.copy&type=original_language&phase=2';
   		if( confirmCheck.checked == true ) {
 			if( !window.confirm( '<?php echo JText::_('CONFIRM_COPY_TO', true);?>' ) ) return;
 			link += '&overwrite=1';
@@ -75,13 +75,13 @@ defined('_JEXEC') or die('Restricted access'); ?>
 		<td width="45%" valign="top">
 			<div id="cpanel">
 				<?php
-				$link = 'index3.php?option=com_joomfish&amp;task=manage.copy&amp;type=original_language';
+				$link = 'index.php?option=com_joomfish&amp;task=manage.copy&amp;type=original_language';
 				$this->_quickiconButton( $link, 'icon-48-manage-translations.png', JText::_( 'COPY_ORIGINAL_TO_LANGUAGE' ), '/administrator/components/com_joomfish/assets/images/', 'ajaxFrame', "updateResultDiv('" .JText::_('Processing', 'text'). "');" );
 /*
 				echo '<div style="clear: both;" />';
-				$link = 'index3.php?option=com_joomfish&amp;task=copy&amp;act=manage&amp;type=translation_language';
+				$link = 'index.php?option=com_joomfish&amp;task=copy&amp;act=manage&amp;type=translation_language';
 				HTML_joomfish::_quickiconButton( $link, 'dbrestore.png', JText::_( 'COPY_TRANSLATION_TO_LANGAGE' ), '/administrator/images/', 'ajaxFrame', "updateResultDiv('" .JText::_('Processing', 'text'). "');" );
-				$link = 'index3.php?option=com_joomfish&amp;task=update&amp;act=manage&amp;type=original_value';
+				$link = 'index.php?option=com_joomfish&amp;task=update&amp;act=manage&amp;type=original_value';
 				HTML_joomfish::_quickiconButton( $link, 'query.png', JText::_( 'UPDATE_ORIGINAL_VALUES' ), '/administrator/images/', 'ajaxFrame', "updateResultDiv('" .JText::_( 'UPDATE_ORIGINAL_VALUES' ). "', 'text');" );
 */
 				?>

--- a/admin/views/statistics/tmpl/default.php
+++ b/admin/views/statistics/tmpl/default.php
@@ -49,9 +49,9 @@ defined('_JEXEC') or die('Restricted access'); ?>
 		<td width="55%" valign="top">
 			<div id="cpanel">
 				<?php
-				$link = 'index3.php?option=com_joomfish&amp;task=statistics.check&amp;type=translation_status';
+				$link = 'index.php?option=com_joomfish&amp;task=statistics.check&amp;type=translation_status';
 				$this->_quickiconButton( $link, 'icon-48-checktranslations.png', JText::_( 'CHECK_TRANSLATION_STATUS' ), '/administrator/components/com_joomfish/assets/images/', 'ajaxFrame', "updateResultDiv('" .JText::_( 'CHECK_TRANSLATION_STATUS' ). "', 'text');" );
-				$link = 'index3.php?option=com_joomfish&amp;task=statistics.check&amp;type=original_status';
+				$link = 'index.php?option=com_joomfish&amp;task=statistics.check&amp;type=original_status';
 				$this->_quickiconButton( $link, 'icon-48-checktranslations.png', JText::_( 'CHECK_ORIGINAL_STATUS' ), '/administrator/components/com_joomfish/assets/images/', 'ajaxFrame', "updateResultDiv('" .JText::_( 'CHECK_ORIGINAL_STATUS' ). "', 'text');" );
 				?>
 			</div>


### PR DESCRIPTION
See issue #45.

Both the "Manage Translations" screen and the "Statistics" screen used index3.php instead of index.php. Joomla! 2.5 no longer uses index2 nor index3.

After reading these two links http://groups.google.com/group/joomla-dev-general/browse_thread/thread/b6f629e51dc4ef46 and http://docs.joomla.org/Adapting_a_Joomla_1.5_extension_to_Joomla_1.6 and testing changing index3.php to index.php I think that the changes here are enough. (There are no index2.php entries.)

However, the translations are still not copied in my case, see http://www.joomfish.net/forumviewtopic.php?f=48&t=11239#p38270, although Caniggia in that thread says "_Once You change references from index3.php to index.php everything works fine._".

There is one index3.php left: /admin/views/translate/tmpl/edit.php on line 238 (https://github.com/JoomFish/jf-future/blob/master/admin/views/translate/tmpl/edit.php#L237). Since I don't know what this file does, and I don't seem to be able to test this I did not change it.
