### PR TITLE
Modified installer: system plugins order numbers are 'reordered' after installation of plugins

### DIFF
--- a/install.php
+++ b/install.php
@@ -107,7 +107,10 @@ class com_JoomfishInstallerScript
             WHERE ".$db->nameQuote("element")." IN (".$db->quote("jfrouter").",".$db->quote("jfdatabase").",".$db->quote("jfoverrides").")";
             $db->setQuery($query);
             $db->query();
-            
+			// Reorder table #__extensions where type=plugin and folder=system
+			$table = new JTableExtension($db);
+			$whereOrder = $db->nameQuote("folder").'='.$db->quote("system").' AND '.$columnType.'='.$db->quote("plugin");
+			$table->reorder($whereOrder);
         }
  
         /**


### PR DESCRIPTION
When JoomFish is installed its three plugins have order numbers 1, 2 and 3, and all the plugins that were present before that were moved up by 3. With this reordering (reorder function of JTable) the ordering numbers are set sequentially.
