### PR TITLE
Fatal error in menu params when there is a fieldset description

### DIFF
--- a/libraries/joomfish/translateparams/xml.php
+++ b/libraries/joomfish/translateparams/xml.php
@@ -215,7 +215,7 @@ class TranslateParams_xml extends TranslateParams
 				echo $sliders->startPanel(JText::_($label), $name . '-options');
 		
 				if (isset($fieldSet->description) && trim($fieldSet->description)) :
-				echo '<p class="tip">' . $this->escape(JText::_($fieldSet->description)) . '</p>';
+				echo '<p class="tip">' . JText::_($fieldSet->description) . '</p>';
 				endif;
 				?>
 						<div class="clr"></div>


### PR DESCRIPTION
$this->escape is not allowed in your class. It generates the following error:

> Fatal error: Using $this when not in object context in /.../libraries/joomfish/translateparams/xml.php on line 218.

This PR just removes the escape call as a workaround. If the escaping is needed you need to rewrite it.
